### PR TITLE
Update public-folder-not-send-read-receipt.md

### DIFF
--- a/Exchange/ExchangeOnline/public-folders/public-folder-not-send-read-receipt.md
+++ b/Exchange/ExchangeOnline/public-folders/public-folder-not-send-read-receipt.md
@@ -21,9 +21,10 @@ search.appverid: MET150
 
 # Read receipts are sent from a public folder mailbox instead of from a public folder
 
-When you send a message to a mail-enabled public folder, you can request that a read receipt be sent to you after the message is marked as **Read**. In your email client, such as [Microsoft Outlook](https://support.microsoft.com/office/add-and-request-read-receipts-and-delivery-notifications-a34bf70a-4c2c-4461-b2a1-12e4a7a92141) or [Outlook on the web](https://support.microsoft.com/office/read-receipts-in-outlook-on-the-web-e09af74d-3519-45fc-a680-37a538a92157), you can select the option to request a read receipt before you send the message.
+When you send a message to a mail-enabled public folder, you can request that a read receipt be sent to you after the message is marked as **Read**. In your email client, such as [Microsoft Outlook](https://support.microsoft.com/office/add-and-request-read-receipts-and-delivery-notifications-a34bf70a-4c2c-4461-b2a1-12e4a7a92141) or [Outlook on the web](https://support.microsoft.com/office/read-receipts-in-outlook-on-the-web-e09af74d-3519-45fc-a680-37a538a92157), you can select the option to request a read receipt before you send the message & ensure that email client "OWA/Outlook" used has adjusted the response to the read receipt requests setting to be Always send a response(OWA) or Always send a read recipt(Outlook).
 
-For the public folder to comply with your read receipt request, the value of the `PerUserReadStateEnabled` parameter on the public folder must be set to **False**. This value indicates that data should not be maintained about which messages are read and unread by each user who has permissions to the public folder.
+For the public folder to comply with your read receipt request,the value of the `PerUserReadStateEnabled` parameter on the public folder must be set to **False**. This value indicates that data should not be maintained about which messages are read and unread by each user who has permissions to the public folder.
+
 
 To check the current value of the `PerUserReadStateEnabled` parameter on the public folder, run the following cmdlet:
 


### PR DESCRIPTION
This part added is crucial to have the read receipts confirmation sent properly when the action taken on the mail public folder to read a message with read receipt request inside.